### PR TITLE
Mute uploaded video by default

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -193,7 +193,7 @@
                 </button>
               </div>
             </div>
-            <video id="surgery-video" class="w-full" style="max-height: 55vh;" controls autoplay>
+            <video id="surgery-video" class="w-full" style="max-height: 55vh;" controls autoplay muted>
               <source src="{{ video_src|default('/static/sample_video.mp4') }}" type="video/mp4">
               Your browser does not support the video tag.
             </video>


### PR DESCRIPTION
This change mutes audio by default when the video playback of the uploaded or selected video starts.