### PR TITLE
Keep chat window only for user query/responses

### DIFF
--- a/web/static/main.js
+++ b/web/static/main.js
@@ -344,15 +344,11 @@ function handleServerMessage(message) {
     if (message.agent_response.startsWith('Annotation:')) {
       // Add to annotations panel
       addAnnotation(message.agent_response);
-      // Also add to chat as normal
-      addMessageToChat(message.agent_response, 'agent');
-    } 
+    }
     // Check if this is a note (or has is_note flag)
     else if (message.is_note || message.agent_response.toLowerCase().includes('note:')) {
       // Add to notes panel with user's original message if available
       addNote(message.agent_response, message.original_user_input || message.user_input || '');
-      // Also add to chat
-      addMessageToChat(message.agent_response, 'agent');
     }
     else {
       // Regular response - just add to chat


### PR DESCRIPTION
This change removes annotations and notes being sent also to the chat window. Both annotations and notes will be sent only to the respective windows.