### PR TITLE
fix: prevent video autoplay and improve Whisper server stability

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -216,8 +216,8 @@
                 </button>
               </div>
             </div>
-            <video id="surgery-video" class="w-full" style="max-height: 55vh;" controls autoplay muted>
-              <source src="{{ video_src|default('/static/sample_video.mp4') }}" type="video/mp4">
+            <video id="surgery-video" class="w-full" style="max-height: 55vh;" controls muted>
+              <source src="" type="video/mp4">
               Your browser does not support the video tag.
             </video>
             <div class="p-2 bg-dark-800 flex justify-between">


### PR DESCRIPTION
Video Player Fixes:
- Remove autoplay attribute from video element to prevent auto-start on page reload
- Reset video source to empty state on page load initialization
- Add showVideoPlaceholder() function to display "No Video Selected" message
- Replace autoplay=true with explicit play() calls in selectVideo/uploadVideo
- Clear poster attribute when loading new videos for clean state transitions

Whisper Server Improvements:
- Add SO_REUSEADDR socket option to prevent "Address already in use" errors
- Implement comprehensive error handling for BrokenPipeError and ConnectionResetError
- Add empty data validation in serve_one_connection()
- Ensure graceful connection cleanup with try/finally blocks
- Improve server stability during client disconnections

These changes resolve issues where:
- Videos would auto-start showing previous content on page reload
- Whisper server would crash on port conflicts and broken pipe errors
- Users experienced confusing video states without clear feedback

Fixes video playback control and enhances overall system reliability.