### PR TITLE
feat: Add current frame UI display with real-time status

### DIFF
--- a/web/static/main.js
+++ b/web/static/main.js
@@ -1178,6 +1178,11 @@ function completeMessageSend(message, frameData) {
 
   // Send payload to server
   if (typeof sendJSON === 'function') {
+    // Show sending status if we have frame data
+    if (frameData) {
+      showFrameSendingStatus();
+    }
+
     sendJSON(payload);
     console.log("Message sent to backend" + (frameData ? " with frame data" : " WITHOUT frame data"));
   } else {
@@ -1563,12 +1568,16 @@ function captureAndStoreFrame() {
     if (frameData) {
       // Store the captured frame in sessionStorage
       sessionStorage.setItem('lastCapturedFrame', frameData);
+      // Update the display with manual capture status
+      updateCapturedFrameDisplay(frameData, 'Manually captured', 'manual');
       showToast('Frame captured successfully!', 'success');
     } else {
+      updateFrameStatus('Failed to capture frame', 'text-xs text-red-400');
       showToast('Failed to capture frame - video not playing', 'error');
     }
   } catch (err) {
     console.error('Error capturing frame:', err);
+    updateFrameStatus('Capture error: ' + err.message, 'text-xs text-red-400');
     showToast('Error capturing frame: ' + err.message, 'error');
   }
 }
@@ -1621,6 +1630,9 @@ function startAutoFrameCapture() {
     sessionStorage.setItem('lastCapturedFrame', initialFrame);
     console.log("Initial frame captured and stored successfully");
 
+    // Update the display
+    updateCapturedFrameDisplay(initialFrame, 'Initial frame captured', 'auto');
+
     // Send to server for annotation
     if (typeof sendJSON === 'function') {
       sendJSON({
@@ -1658,6 +1670,7 @@ function startAutoFrameCapture() {
       // Try to use any previously stored frame for annotation
       const lastFrame = sessionStorage.getItem('lastCapturedFrame');
       if (lastFrame && typeof sendJSON === 'function') {
+        updateCapturedFrameDisplay(lastFrame, 'Auto-capture failed - using previous', 'fallback');
         sendJSON({
           auto_frame: true,
           frame_data: lastFrame
@@ -1713,11 +1726,14 @@ function captureVideoFrame() {
     const lastFrame = sessionStorage.getItem('lastCapturedFrame');
     if (lastFrame) {
       console.log("Using previous frame since video isn't ready for capture");
+      updateCapturedFrameDisplay(lastFrame, 'Video not ready - using previous', 'fallback');
       return lastFrame;
     }
 
     // Create a placeholder frame if we can't get a real one
-    return createPlaceholderFrame();
+    const placeholder = createPlaceholderFrame();
+    updateCapturedFrameDisplay(placeholder, 'Video not ready - using placeholder', 'placeholder');
+    return placeholder;
   }
 
   try {
@@ -1728,7 +1744,9 @@ function captureVideoFrame() {
     if (videoElement.videoWidth === 0 || videoElement.videoHeight === 0) {
       console.warn('Video dimensions are not available yet');
       // Return a placeholder frame instead of trying with default dimensions
-      return createPlaceholderFrame();
+      const placeholder = createPlaceholderFrame();
+      updateCapturedFrameDisplay(placeholder, 'No video dimensions - using placeholder', 'placeholder');
+      return placeholder;
     } else {
       canvas.width = videoElement.videoWidth;
       canvas.height = videoElement.videoHeight;
@@ -1747,11 +1765,14 @@ function captureVideoFrame() {
       const lastFrame = sessionStorage.getItem('lastCapturedFrame');
       if (lastFrame) {
         console.log("Using last captured frame after drawing error");
+        updateCapturedFrameDisplay(lastFrame, 'Drawing error - using previous', 'fallback');
         return lastFrame;
       }
 
       // Fallback to placeholder
-      return createPlaceholderFrame();
+      const placeholder = createPlaceholderFrame();
+      updateCapturedFrameDisplay(placeholder, 'Drawing error - using placeholder', 'placeholder');
+      return placeholder;
     }
 
     // Convert to base64 data URL
@@ -1765,14 +1786,20 @@ function captureVideoFrame() {
       const lastFrame = sessionStorage.getItem('lastCapturedFrame');
       if (lastFrame) {
         console.log("Invalid data URL - using previous frame instead");
+        updateCapturedFrameDisplay(lastFrame, 'Invalid data - using previous', 'fallback');
         return lastFrame;
       }
 
-      return createPlaceholderFrame();
+      const placeholder = createPlaceholderFrame();
+      updateCapturedFrameDisplay(placeholder, 'Invalid data - using placeholder', 'placeholder');
+      return placeholder;
     }
 
     // Store successfully captured frame in session storage for fallback
     sessionStorage.setItem('lastCapturedFrame', dataURL);
+
+    // Update the captured frame display in the UI
+    updateCapturedFrameDisplay(dataURL, 'Frame captured', 'video');
 
     console.log('Frame captured successfully');
     return dataURL;
@@ -1783,11 +1810,14 @@ function captureVideoFrame() {
     const lastFrame = sessionStorage.getItem('lastCapturedFrame');
     if (lastFrame) {
       console.log("Using previously captured frame after error");
+      updateCapturedFrameDisplay(lastFrame, 'Using previous frame', 'fallback');
       return lastFrame;
     }
 
     // If nothing else works, create a placeholder
-    return createPlaceholderFrame();
+    const placeholder = createPlaceholderFrame();
+    updateCapturedFrameDisplay(placeholder, 'Placeholder frame', 'placeholder');
+    return placeholder;
   }
 }
 
@@ -3600,5 +3630,84 @@ function getWebSocketStateText(state) {
     case WebSocket.CLOSING: return 'CLOSING (2)';
     case WebSocket.CLOSED: return 'CLOSED (3)';
     default: return `UNKNOWN (${state})`;
+  }
+}
+
+// ============================================================================
+// CAPTURED FRAME DISPLAY FUNCTIONS
+// ============================================================================
+
+// Update the captured frame display in the UI
+function updateCapturedFrameDisplay(frameData, status = 'Captured', source = 'manual') {
+  const frameImage = document.getElementById('captured-frame-image');
+  const framePlaceholder = document.getElementById('captured-frame-placeholder');
+  const frameStatus = document.getElementById('frame-status');
+  const frameTimestamp = document.getElementById('frame-timestamp');
+
+  if (!frameImage || !framePlaceholder || !frameStatus || !frameTimestamp) {
+    console.warn('Captured frame display elements not found');
+    return;
+  }
+
+  if (frameData) {
+    // Show the captured frame
+    frameImage.src = frameData;
+    frameImage.classList.remove('hidden');
+    framePlaceholder.classList.add('hidden');
+
+    // Update status and timestamp
+    frameStatus.textContent = status;
+    frameStatus.className = 'text-xs text-green-400';
+
+    const now = new Date();
+    const timeString = now.toLocaleTimeString();
+    frameTimestamp.textContent = `${timeString} (${source})`;
+
+    console.log(`Frame display updated: ${status} from ${source}`);
+  } else {
+    // Show placeholder
+    frameImage.classList.add('hidden');
+    framePlaceholder.classList.remove('hidden');
+
+    frameStatus.textContent = 'No frame available';
+    frameStatus.className = 'text-xs text-gray-400';
+    frameTimestamp.textContent = '';
+  }
+}
+
+// Show the sending overlay when frame is being sent to vLLM
+function showFrameSendingStatus() {
+  const overlay = document.getElementById('frame-sending-overlay');
+  const frameStatus = document.getElementById('frame-status');
+
+  if (overlay) {
+    overlay.classList.remove('hidden');
+    overlay.classList.add('flex');
+  }
+
+  if (frameStatus) {
+    frameStatus.textContent = 'Sending for AI Analysis...';
+    frameStatus.className = 'text-xs text-primary-400';
+  }
+
+  // Hide the overlay after a short time
+  setTimeout(() => {
+    if (overlay) {
+      overlay.classList.add('hidden');
+      overlay.classList.remove('flex');
+    }
+    if (frameStatus) {
+      frameStatus.textContent = 'Sent for AI Analysis';
+      frameStatus.className = 'text-xs text-green-400';
+    }
+  }, 1500);
+}
+
+// Update frame status without changing the image
+function updateFrameStatus(status, className = 'text-xs text-gray-400') {
+  const frameStatus = document.getElementById('frame-status');
+  if (frameStatus) {
+    frameStatus.textContent = status;
+    frameStatus.className = className;
   }
 }

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -230,6 +230,35 @@
                 </span>
               </div>
             </div>
+
+            <!-- Captured Frame Display -->
+            <div class="p-2 bg-dark-900 border-t border-dark-700">
+              <div class="flex items-center justify-between mb-2">
+                <h6 class="font-medium text-white text-sm flex items-center m-0">
+                  <i class="fas fa-camera text-primary-400 mr-2"></i> Current Frame for AI Analysis
+                </h6>
+                <div class="flex items-center space-x-2">
+                  <span id="frame-status" class="text-xs text-gray-400">No frame captured</span>
+                  <div id="frame-timestamp" class="text-xs text-gray-500"></div>
+                </div>
+              </div>
+              <div id="captured-frame-container" class="relative">
+                <div id="captured-frame-placeholder" class="w-full h-24 bg-dark-700 border border-dark-600 rounded-lg flex items-center justify-center text-gray-400 text-sm">
+                  <div class="text-center">
+                    <i class="fas fa-image text-2xl mb-2 text-gray-500"></i>
+                    <div>No frame captured yet</div>
+                    <div class="text-xs text-gray-500 mt-1">Frame will appear here when captured</div>
+                  </div>
+                </div>
+                <img id="captured-frame-image" class="w-full h-24 object-contain bg-dark-700 border border-dark-600 rounded-lg hidden" alt="Captured frame">
+                <div id="frame-sending-overlay" class="absolute inset-0 bg-primary-600 bg-opacity-20 rounded-lg items-center justify-center hidden">
+                  <div class="text-center text-white">
+                    <i class="fas fa-paper-plane text-lg mb-1"></i>
+                    <div class="text-xs">Sending for AI Analysis...</div>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Add sidebar component showing captured frame preview, capture status, and sending feedback for improved visibility into AI analysis workflow.

Below are some screenshots of the visualization:

Placeholder:
<img width="1142" height="998" alt="image" src="https://github.com/user-attachments/assets/a8b80743-98a0-47b6-a19b-800b171d6e6a" />

Captured Image:
<img width="1132" height="1004" alt="image" src="https://github.com/user-attachments/assets/db6a258c-dc96-4820-bc17-10c019a40474" />

Frame sent for analysis:
<img width="1139" height="995" alt="image" src="https://github.com/user-attachments/assets/f93b5a41-9cd0-4202-bc72-d3f5648ea150" />
