### PR TITLE
Switch default model to Qwen2.5-VL-7B-Surg-CholecT50

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ npm install
     * Whisper (speech‑to‑text) checkpoints live in models/whisper/ (they will be downloaded automatically at runtime the first time you invoke Whisper).
 
 * Default LLM
-    * This repository is pre‑configured for [NVIDIA Llama‑3.2‑11B‑Vision‑Surgical‑CholecT50](https://huggingface.co/nvidia/Llama-3.2-11B-Vision-Surgical-CholecT50), a surgical‑domain fine‑tuned variant of Llama 3.2‑11B. You may choose to replace it with a finetuned VLM of your choosing.
+    * This repository is pre‑configured for [NVIDIA Qwen2.5-VL-7B-Surg-CholecT50](https://huggingface.co/nvidia/Qwen2.5-VL-7B-Surg-CholecT50), a surgical‑domain fine‑tuned variant of Qwen2.5-VL-7B. You may choose to replace it with a finetuned VLM of your choosing.
 
 Download the default model from Hugging Face with Git LFS:
 
 ```
 # Download the checkpoint into the expected folder
-huggingface-cli download nvidia/Llama-3.2-11B-Vision-Surgical-CholecT50 \
-  --local-dir models/llm/Llama-3.2-11B-Vision-Surgical-CholecT50 \
+huggingface-cli download nvidia/Qwen2.5-VL-7B-Surg-CholecT50 \
+  --local-dir models/llm/Qwen2.5-VL-7B-Surg-CholecT50 \
   --local-dir-use-symlinks False     
 ```
 
@@ -102,8 +102,8 @@ huggingface-cli download nvidia/Llama-3.2-11B-Vision-Surgical-CholecT50 \
 ```
 models/
   ├── llm/
-  │   └── Llama-3.2-11B-Vision-Surgical-CholecT50/   ← LLM model files
-  └── whisper/                                       ← Whisper models (auto‑downloaded)
+  │   └── Qwen2.5-VL-7B-Surg-CholecT50/   ← LLM model files
+  └── whisper/                            ← Whisper models (auto‑downloaded)
 ```
 
 ### Fine‑Tuning Your Own Surgical Model

--- a/configs/global.yaml
+++ b/configs/global.yaml
@@ -1,5 +1,4 @@
-model_name: "models/llm/Llama-3.2-11B-Vision-Surgical-CholecT50/"
-#model_name: "models/llm/Qwen2.5-VL-7B-Surgical-CholecT50"
+model_name: "models/llm/Qwen2.5-VL-7B-Surg-CholecT50/"
 served_model_name: "surgical-vlm"
 llm_url: "http://127.0.0.1:8000/v1"
 personnel:

--- a/docker/README.md
+++ b/docker/README.md
@@ -132,7 +132,7 @@ rm -rf vllm
 docker run -it --rm --net host --gpus all \
   -v <path-to-repo>/models:/vllm-workspace/models \
   vlm-surgical-agents:vllm-openai-v0.8.3-dgpu \
-  --model models/llm/Llama-3.2-11B-lora-surgical-4bit \
+  --model models/llm/Qwen2.5-VL-7B-Surg-CholecT50 \
   --enforce-eager \
   --max-model-len 4096 \
   --max-num-seqs 8 \

--- a/docker/run-surgical-agents.sh
+++ b/docker/run-surgical-agents.sh
@@ -66,7 +66,7 @@ get_model_name() {
     fi
 
     # Finally use hardcoded default
-    echo "models/llm/Llama-3.2-11B-Vision-Surgical-CholecT50"
+    echo "models/llm/Qwen2.5-VL-7B-Surg-CholecT50"
 }
 
 # Function to get served model name following precedence: ENV > global.yaml > default
@@ -103,11 +103,11 @@ check_docker() {
     echo -e "${GREEN}✅ Docker is running${NC}"
 }
 
-# Function to download the NVIDIA Llama-3.2-11B-Vision-Surgical-CholecT50 model
-download_nvidia_llama_model() {
-    local model_dir="${REPO_PATH}/models/llm/Llama-3.2-11B-Vision-Surgical-CholecT50"
+# Function to download the NVIDIA Qwen2.5-VL-7B-Surg-CholecT50 model
+download_nvidia_qwen_model() {
+    local model_dir="${REPO_PATH}/models/llm/Qwen2.5-VL-7B-Surg-CholecT50"
 
-    echo -e "\n${BLUE}📥 Downloading NVIDIA Llama-3.2-11B-Vision-Surgical-CholecT50 model...${NC}"
+    echo -e "\n${BLUE}📥 Downloading NVIDIA Qwen2.5-VL-7B-Surg-CholecT50 model...${NC}"
 
     # Install Hugging Face CLI if not present
     if ! command -v huggingface-cli &> /dev/null; then
@@ -124,10 +124,10 @@ download_nvidia_llama_model() {
     fi
 
     # Download the model using Hugging Face CLI
-    echo -e "${YELLOW}🔄 Downloading model using Hugging Face CLI (this may take a while - ~20GB)...${NC}"
+    echo -e "${YELLOW}🔄 Downloading model using Hugging Face CLI (this may take a while - ~14GB)...${NC}"
     echo -e "${BLUE}💡 Download can be resumed if interrupted${NC}"
 
-    huggingface-cli download nvidia/Llama-3.2-11B-Vision-Surgical-CholecT50 \
+    huggingface-cli download nvidia/Qwen2.5-VL-7B-Surg-CholecT50 \
         --local-dir "$model_dir" \
         --resume-download \
         --local-dir-use-symlinks False
@@ -141,26 +141,26 @@ download_nvidia_llama_model() {
 
 }
 
-# Function to check if NVIDIA Llama model exists and download if needed
-ensure_nvidia_llama_model() {
+# Function to check if NVIDIA Qwen model exists and download if needed
+ensure_nvidia_qwen_model() {
     local model_name=$(get_model_name)
     local model_dir="${REPO_PATH}/${model_name}"
     local model_config="${model_dir}/config.json"
 
     # Currently this function only handles downloading
-    # NVIDIA/Llama-3.2-11B-Vision-Surgical-CholecT50 model from Hugging Face.
-    if [[ "$model_name" != *"Llama-3.2-11B-Vision-Surgical-CholecT50"* ]]; then
+    # NVIDIA/Qwen2.5-VL-7B-Surg-CholecT50 model from Hugging Face.
+    if [[ "$model_name" != *"Qwen2.5-VL-7B-Surg-CholecT50"* ]]; then
         return 0
     fi
 
     if [ -f "$model_config" ]; then
-        echo -e "${GREEN}✅ NVIDIA Llama surgical model found at $model_dir${NC}"
+        echo -e "${GREEN}✅ NVIDIA Qwen surgical model found at $model_dir${NC}"
         return 0
     fi
 
-    echo -e "${YELLOW}⚠️  NVIDIA Llama surgical model not found at $model_dir${NC}"
+    echo -e "${YELLOW}⚠️  NVIDIA Qwen surgical model not found at $model_dir${NC}"
     echo -e "${BLUE}📥 Will download the model now...${NC}"
-    download_nvidia_llama_model
+    download_nvidia_qwen_model
     return $?
 }
 
@@ -272,9 +272,9 @@ stop_containers() {
 run_vllm() {
     echo -e "\n${BLUE}🚀 Starting vLLM Server...${NC}"
 
-    # Ensure the NVIDIA Llama surgical model is available (if needed)
-    if ! ensure_nvidia_llama_model; then
-        echo -e "${RED}❌ Failed to ensure NVIDIA Llama surgical model is available. Cannot start vLLM server.${NC}"
+    # Ensure the NVIDIA Qwen surgical model is available (if needed)
+    if ! ensure_nvidia_qwen_model; then
+        echo -e "${RED}❌ Failed to ensure NVIDIA Qwen surgical model is available. Cannot start vLLM server.${NC}"
         return 1
     fi
 

--- a/scripts/run_vllm_server.sh
+++ b/scripts/run_vllm_server.sh
@@ -42,7 +42,7 @@ if [[ -z "${MODEL_NAME_REL}" ]]; then
   MODEL_NAME_REL="$(read_yaml_key model_name || true)"
 fi
 if [[ -z "${MODEL_NAME_REL}" ]]; then
-  MODEL_NAME_REL="models/llm/Llama-3.2-11B-Vision-Surgical-CholecT50"
+  MODEL_NAME_REL="models/llm/Qwen2.5-VL-7B-Surg-CholecT50"
 fi
 
 # Make absolute model path (allow absolute path in config)


### PR DESCRIPTION
Replace NVIDIA Llama-3.2-11B-Vision-Surgical-CholecT50 with the newer Qwen2.5-VL-7B-Surg-CholecT50 model as the default surgical VLM. The Qwen model offers improved performance with a smaller model size while maintaining strong surgical action recognition capabilities on the CholecT50 dataset. Additionally, the new model works well with non-surgical frames, providing better generalization for diverse use cases.

Changes:
- Update default model path in configs/global.yaml
- Update model references in README.md and docker/README.md
- Update model paths in scripts/run_vllm_server.sh
- Update Docker deployment scripts (run-surgical-agents.sh)
- Rename model download functions from llama to qwen variants

Model details:
- Old: nvidia/Llama-3.2-11B-Vision-Surgical-CholecT50 (~11B params)
- New: nvidia/Qwen2.5-VL-7B-Surg-CholecT50 (~7B params)
- HuggingFace: https://huggingface.co/nvidia/Qwen2.5-VL-7B-Surg-CholecT50

Benefits:
- Smaller model size for faster downloads
- Better generalization with non-surgical frames
- Maintained surgical performance on CholecT50 benchmarks

All model references, download instructions, and documentation have been updated to reflect this change.