### PR TITLE
Remove unnecessary sudo and migrate to hf CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Download the default model from Hugging Face with Git LFS:
 
 ```
 # Download the checkpoint into the expected folder
-huggingface-cli download nvidia/Qwen2.5-VL-7B-Surg-CholecT50 \
+hf download nvidia/Qwen2.5-VL-7B-Surg-CholecT50 \
   --local-dir models/llm/Qwen2.5-VL-7B-Surg-CholecT50 \
   --local-dir-use-symlinks False     
 ```

--- a/docker/run-surgical-agents.sh
+++ b/docker/run-surgical-agents.sh
@@ -22,7 +22,7 @@ NC='\033[0m' # No Color
 # Get the absolute path of the repository (parent directory since we're in docker/)
 REPO_PATH=$(dirname $(pwd))
 
-# Ensure ~/.local/bin is in PATH (for huggingface-cli and other user-installed tools)
+# Ensure ~/.local/bin is in PATH (for hf and other user-installed tools)
 export PATH="$HOME/.local/bin:$PATH"
 
 # Detect architecture
@@ -110,7 +110,7 @@ download_nvidia_qwen_model() {
     echo -e "\n${BLUE}📥 Downloading NVIDIA Qwen2.5-VL-7B-Surg-CholecT50 model...${NC}"
 
     # Install Hugging Face CLI if not present
-    if ! command -v huggingface-cli &> /dev/null; then
+    if ! command -v hf &> /dev/null; then
         echo -e "${YELLOW}📦 Installing Hugging Face CLI...${NC}"
         pip install --upgrade huggingface-hub --user
         echo -e "${BLUE}💡 Installed to ~/.local/bin (already in PATH)${NC}"
@@ -119,15 +119,14 @@ download_nvidia_qwen_model() {
     # Create models/llm directory with proper permissions
     if [ ! -d "${REPO_PATH}/models/llm" ]; then
         echo -e "${YELLOW}📁 Creating models/llm directory...${NC}"
-        sudo mkdir -p "${REPO_PATH}/models/llm"
-        sudo chown -R $USER:$USER "${REPO_PATH}/models/llm"
+        mkdir -p "${REPO_PATH}/models/llm"
     fi
 
     # Download the model using Hugging Face CLI
     echo -e "${YELLOW}🔄 Downloading model using Hugging Face CLI (this may take a while - ~14GB)...${NC}"
     echo -e "${BLUE}💡 Download can be resumed if interrupted${NC}"
 
-    huggingface-cli download nvidia/Qwen2.5-VL-7B-Surg-CholecT50 \
+    hf download nvidia/Qwen2.5-VL-7B-Surg-CholecT50 \
         --local-dir "$model_dir" \
         --resume-download \
         --local-dir-use-symlinks False

--- a/scripts/run_vllm_server.sh
+++ b/scripts/run_vllm_server.sh
@@ -74,8 +74,15 @@ trap 'echo "[run_vllm_server.sh] Shutting down…"; pkill -P $$ || true' EXIT
 if [[ ! -d "${MODEL_PATH}" ]]; then
   echo "[run_vllm_server.sh] Model not found at ${MODEL_PATH}"
   if [[ -n "${MODEL_REPO_VAL}" ]]; then
-    echo "[run_vllm_server.sh] Downloading from ${MODEL_REPO_VAL} with huggingface‑cli …"
-    huggingface-cli download "${MODEL_REPO_VAL}" \
+    # Ensure hf CLI is available before attempting download
+    if ! command -v hf &> /dev/null; then
+      echo "[run_vllm_server.sh] Hugging Face CLI not found. Installing..."
+      pip install --upgrade huggingface-hub --user
+      export PATH="$HOME/.local/bin:$PATH"
+    fi
+
+    echo "[run_vllm_server.sh] Downloading from ${MODEL_REPO_VAL} with hf …"
+    hf download "${MODEL_REPO_VAL}" \
         --local-dir "${MODEL_PATH}" \
         --resume-download \
         --local-dir-use-symlinks False
@@ -84,7 +91,7 @@ if [[ ! -d "${MODEL_PATH}" ]]; then
     echo "[run_vllm_server.sh] No MODEL_REPO provided. Skipping auto‑download."
     echo "  Set env MODEL_REPO or add 'model_repo' to configs/global.yaml,"
     echo "  or manually download the model into: ${MODEL_PATH}"
-    echo "  Example: huggingface-cli download nvidia/${MODEL_NAME} --local-dir \"${MODEL_PATH}\" --local-dir-use-symlinks False"
+    echo "  Example: hf download nvidia/${MODEL_NAME} --local-dir \"${MODEL_PATH}\" --local-dir-use-symlinks False"
   fi
 fi
 


### PR DESCRIPTION
- Remove sudo from model directory creation in run-surgical-agents.sh The sudo commands were redundant as they created root-owned directories then immediately chowned them back to the user. Since users own their workspace, they can create directories without elevated privileges.

- Migrate from huggingface-cli to hf command across all scripts The hf command is the modern, shorter alias provided by huggingface-hub. Both scripts now check for hf availability and auto-install if needed, ensuring compatibility with the latest tooling.

- Add hf availability check to run_vllm_server.sh This script can be run independently, so it now includes the same installation logic as run-surgical-agents.sh to ensure hf is available before attempting model downloads.

Files modified:
- docker/run-surgical-agents.sh
- scripts/run_vllm_server.sh
- README.md