### PR TITLE
feat: Add video session tracking for agent state management

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,29 @@ python -m pytest tests/test_video_source_registry.py -v
 ```
 
 
+## Video Session Tracking
+
+Agents can detect when video sources reconnect or change via a `video_source_session_id` counter that auto-increments on:
+- **WebRTC connections** (frontend signals when stream starts)
+- **Video uploads** (new file uploaded)
+- **Video selections** (existing file selected)
+- **Mode switches** (different video source detected)
+
+This prevents agents from maintaining stale state when reconnecting to the same source.
+
+**Usage:** Add `get_session_id` to agent dependencies, then check for changes:
+```python
+def __init__(self, settings_path, response_handler, get_session_id=None):
+    super().__init__(settings_path, response_handler, get_session_id=get_session_id)
+    self._last_session_id = None
+
+def process_request(self, text, chat_history, visual_info=None):
+    if self.get_session_id and self._last_session_id != self.get_session_id():
+        self._last_session_id = self.get_session_id()
+        # Reset agent state here
+```
+
+
 ## System Requirements
 
 * Python 3.12 or higher

--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -36,7 +36,7 @@ class Agent(ABC):
 
     _llm_lock = Lock()
 
-    def __init__(self, settings_path, response_handler, agent_key=None, message_bus=None):
+    def __init__(self, settings_path, response_handler, agent_key=None, message_bus=None, get_session_id=None):
         self._logger = logging.getLogger(f"{__name__}.{type(self).__name__}")
 
         self.load_settings(settings_path, agent_key=agent_key)
@@ -57,6 +57,12 @@ class Agent(ABC):
             self.message_queue = self.message_bus.register_agent(self.agent_name)
             self._start_message_listener()
             self._logger.info(f"{self.agent_name} registered with message bus")
+
+        # Session tracking integration (optional)
+        # Agents can use this to detect when video sources reconnect/change
+        self.get_session_id = get_session_id
+        if self.get_session_id:
+            self._logger.debug(f"{self.agent_name} registered with session tracking")
 
     def load_settings(self, settings_path, agent_key=None):
         """

--- a/servers/app.py
+++ b/servers/app.py
@@ -169,6 +169,10 @@ async def main():
     registry.register_dependency_resolver("get_video_source_mode", lambda: lambda: web.video_source_mode)
     logger.info("✓ Video source mode getter registered as dependency")
 
+    # Register video session ID getter (for agents to detect reconnections/video changes)
+    registry.register_dependency_resolver("get_session_id", lambda: web.get_session_id)
+    logger.info("✓ Video session ID getter registered as dependency")
+
     # Register annotation agent (will be updated after instantiation)
     annotation_agent_ref = {'agent': None}
     registry.register_dependency_resolver("annotation_agent", lambda: annotation_agent_ref['agent'])

--- a/web/static/main.js
+++ b/web/static/main.js
@@ -45,7 +45,7 @@ function createFrameMessagePayload(frameData) {
 
   // Determine which video source mode we're in based on source_type
   let sourceMode = currentVideoSourceMode;
-  
+
   // If WebRTC is connected, find the source with source_type='livestream'
   if (isWebRTCConnected) {
     // Find the source mode that has source_type='livestream'
@@ -424,6 +424,18 @@ document.addEventListener('DOMContentLoaded', function() {
       setWebRTCButtonsState(false, true);
 
       console.log('WebRTC connection established successfully');
+
+      // Wait for video source config to load before signaling and capturing frames
+      await videoConfigPromise;
+
+      // Signal backend that WebRTC stream started (for session tracking)
+      if (typeof sendJSON === 'function') {
+        sendJSON({
+          type: 'webrtc_stream_started',
+          timestamp: Date.now()
+        });
+        console.log('Sent webrtc_stream_started signal to backend');
+      }
 
       // Start auto frame capture for live stream
       startAutoFrameCapture();


### PR DESCRIPTION
Implement session tracking to help agents detect when video sources reconnect or change, preventing stale state issues.

Changes:
- Add video_source_session_id counter in web_server.py that increments on:
  * WebRTC stream connections (explicit signal from frontend)
  * Video uploads
  * Video selections
  * Video source mode switches
- Register get_session_id() as agent dependency in app.py
- Add optional get_session_id parameter to base Agent class
- Send webrtc_stream_started signal from frontend on connection
- Add session tracking documentation to README

Benefits:
- Agents can now detect reconnections to the same video source
- Prevents double-counting when mode switches on initial connection
- Fixes issue where agents maintained stale state (e.g., alert_sent=True) after disconnect/reconnect to the same mode

Usage:
Agents add get_session_id to dependencies and check for changes:
  if self.get_session_id and self._last_session_id != self.get_session_id():
      # Reset agent state

Resolves feedback about agents being unable to detect reconnections when video source mode doesn't change.