### PR TITLE
Use prebuilt vLLM container for IGX Thor

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -97,6 +97,10 @@ VLLM_ENFORCE_EAGER=true ./run-surgical-agents.sh run vllm
 GPU_MEMORY_UTILIZATION=0.5 VLLM_ENFORCE_EAGER=true ./run-surgical-agents.sh
 ```
 
+### IGX Thor Support
+
+The framework includes optimized support for NVIDIA IGX Thor devices. When running on IGX Thor hardware, the system automatically detects the device and uses NVIDIA's prebuilt optimized vLLM container instead of building from source. This provides faster setup times and better performance on Thor hardware while maintaining full compatibility with x86_64 and aarch64 platforms. No additional configuration is required.
+
 ### Service Endpoints
 
 Once running, the following services will be available:

--- a/docker/run-surgical-agents.sh
+++ b/docker/run-surgical-agents.sh
@@ -29,10 +29,23 @@ export PATH="$HOME/.local/bin:$PATH"
 ARCH=$(uname -m)
 echo -e "${BLUE}🔍 Detected architecture: $ARCH${NC}"
 
-# Set vLLM image based on architecture
+# Detect if running on IGX Thor
+IS_IGX_THOR=false
+if [ -f /proc/device-tree/model ]; then
+    DEVICE_MODEL=$(cat /proc/device-tree/model 2>/dev/null | tr -d '\0')
+    if [[ "$DEVICE_MODEL" =~ "Thor" ]] || [[ "$DEVICE_MODEL" =~ "IGX" ]]; then
+        IS_IGX_THOR=true
+        echo -e "${BLUE}🔍 Detected IGX Thor device${NC}"
+    fi
+fi
+
+# Set vLLM image based on architecture and platform
 if [[ "$ARCH" == "x86_64" ]]; then
     VLLM_IMAGE="vllm/vllm-openai:latest"
     echo -e "${BLUE}💡 Using official vLLM image for x86_64: $VLLM_IMAGE${NC}"
+elif [[ "$IS_IGX_THOR" == true ]]; then
+    VLLM_IMAGE="nvcr.io/nvidia/vllm:25.11-py3"
+    echo -e "${BLUE}💡 Using NVIDIA NGC vLLM image for IGX Thor: $VLLM_IMAGE${NC}"
 elif [[ "$ARCH" == "aarch64" ]]; then
     VLLM_IMAGE="vlm-surgical-agents:vllm-openai-v0.8.3-dgpu"
     echo -e "${BLUE}💡 Will build custom vLLM image for aarch64: $VLLM_IMAGE${NC}"
@@ -169,6 +182,10 @@ build_vllm() {
         echo -e "${YELLOW}📥 Pulling official vLLM image for x86_64...${NC}"
         docker pull $VLLM_IMAGE
         echo -e "${GREEN}✅ vLLM image ready${NC}"
+    elif [[ "$IS_IGX_THOR" == true ]]; then
+        echo -e "${YELLOW}📥 Pulling NVIDIA NGC vLLM image for IGX Thor...${NC}"
+        docker pull $VLLM_IMAGE
+        echo -e "${GREEN}✅ vLLM image ready${NC}"
     else
         echo -e "${YELLOW}🔨 Building vLLM from source for $ARCH...${NC}"
         cd "$REPO_PATH"
@@ -290,9 +307,23 @@ run_vllm() {
     # Get model name following precedence: ENV > global.yaml > default
     local model_name=$(get_model_name)
     echo -e "${BLUE}💡 Using model: $model_name${NC}"
+
+    # Convert host path to container path
+    # If model_name starts with "models/", convert it to container path
+    local container_model_path="$model_name"
+    if [[ "$model_name" == models/* ]]; then
+        # Remove leading "models/" and prepend container mount path
+        container_model_path="/vllm-workspace/models/${model_name#models/}"
+    elif [[ "$model_name" != /* ]]; then
+        # If it's a relative path but doesn't start with "models/", assume it's relative to models dir
+        container_model_path="/vllm-workspace/models/$model_name"
+    fi
+    echo -e "${BLUE}💡 Container model path: $container_model_path${NC}"
+
     local served_model_name=$(get_served_model_name)
     echo -e "${BLUE}💡 Using served model: $served_model_name${NC}"
 
+    # Run docker command with conditional parameters based on platform
     docker run -d \
         --name vlm-surgical-vllm \
         --net host \
@@ -302,13 +333,14 @@ run_vllm() {
         -e VLLM_URL \
         --restart unless-stopped \
         $VLLM_IMAGE \
-        --model $model_name \
+        $( [[ "$IS_IGX_THOR" == true ]] && echo "vllm serve $container_model_path" || echo "--model $model_name" ) \
+        --served-model-name surgical-vlm \
         --gpu-memory-utilization ${GPU_MEMORY_UTILIZATION} \
-        ${ENFORCE_EAGER_FLAG} \
+        $( [[ "$IS_IGX_THOR" != true ]] && echo "${ENFORCE_EAGER_FLAG}" ) \
         --max-model-len 4096 \
         --max-num-seqs 8 \
-        --load-format bitsandbytes \
-        --quantization bitsandbytes \
+        $( [[ "$IS_IGX_THOR" != true ]] && echo "--load-format bitsandbytes" ) \
+        $( [[ "$IS_IGX_THOR" != true ]] && echo "--quantization bitsandbytes" ) \
         $( [[ -n "${served_model_name}" ]] && echo --served-model-name "${served_model_name}" )
     echo -e "${GREEN}✅ vLLM Server started${NC}"
 }


### PR DESCRIPTION
This commit adds support for using the prebuilt NVIDIA vLLM container (nvcr.io/nvidia/vllm:25.11-py3) when running on IGX Thor devices.

Changes:
- Add automatic detection of IGX Thor devices by checking /proc/device-tree/model
- Use prebuilt NGC vLLM container for Thor instead of building from source
- Adjust docker run parameters for Thor:
  * Use "vllm serve" command format instead of --model flag
  * Disable bitsandbytes quantization (not supported on Thor)
  * Disable enforce-eager flag for Thor
  * Add container model path conversion logic
  * Add --disable-mm-preprocessor-cache flag