### PR TITLE
Fix message loss caused by shared queue

### DIFF
--- a/servers/app.py
+++ b/servers/app.py
@@ -395,12 +395,18 @@ async def main():
     # MESSAGE CALLBACK: Handle user input and route to agents
     # ============================================================================
 
-    def msg_callback(payload, msg_type, timestamp):
+    def msg_callback(payload, msg_type, timestamp, reply_to=None):
         """
         Called when the user manually types input or when the webserver passes along an ASR transcript,
         and when special control actions (e.g., clear_history requests) are received to manage chat and
         message history.
+        reply_to: if set, the WebSocket connection that sent this message; responses are sent only to this client.
         """
+        def send_reply(p):
+            if reply_to is not None and hasattr(web, 'send_message_to'):
+                web.send_message_to(p, reply_to)
+            else:
+                web.send_message(p)
         if 'clear_history' in payload:
             chat_history.reset()
             message_bus.clear_history()
@@ -457,7 +463,7 @@ IMPORTANT: This is a TEXT-ONLY SUMMARY request. Do not attempt to identify instr
                 chat_history.add_bot_message(response_data["response"])
 
                 # Send result to UI with special flag for summary
-                web.send_message({
+                send_reply({
                     "agent_response": response_data["response"],
                     "agent_name": response_data.get("name", "AI Assistant"),
                     "summary_response": True
@@ -585,7 +591,7 @@ IMPORTANT: This is a TEXT-ONLY SUMMARY request. Do not attempt to identify instr
                             }
                             # Also send the structured note to the UI Summary tab via WebSocket
                             try:
-                                web.send_message({
+                                send_reply({
                                     "post_op_note": final_json,
                                     "summary_response": True
                                 })
@@ -617,7 +623,7 @@ IMPORTANT: This is a TEXT-ONLY SUMMARY request. Do not attempt to identify instr
                 # Check if this is from the NotetakerAgent to tag it for the UI
                 if selected_agent_name == "NotetakerAgent":
                     # Pass along the original user input so the UI can infer note content/title
-                    web.send_message({
+                    send_reply({
                         "agent_response": response_data["response"],
                         "agent_name": response_data.get("name", "AI Assistant"),
                         "is_note": True,
@@ -626,7 +632,7 @@ IMPORTANT: This is a TEXT-ONLY SUMMARY request. Do not attempt to identify instr
                     })
                 else:
                     # Send result to UI
-                    web.send_message({
+                    send_reply({
                         "agent_response": response_data["response"],
                         "agent_name": response_data.get("name", "AI Assistant"),
                     })

--- a/servers/web_server.py
+++ b/servers/web_server.py
@@ -118,8 +118,9 @@ class Webserver(threading.Thread):
         self.app.add_url_rule('/api/video_sources', view_func=self.video_sources_route, methods=['GET'])
         self.app.add_url_rule('/videos/<path:filename>', view_func=self.serve_video, methods=['GET'])
 
-        # For text messages from WebSocket - make sure we listen on all interfaces
-        self.ws_queue = queue.Queue()
+        # Track connected WebSocket clients for broadcast-style message delivery
+        self._ws_clients = set()
+        self._ws_clients_lock = threading.Lock()
         # Configure WebSocket with longer ping timeout and interval for more reliability
         self.ws_server = websocket_serve(
             self.on_websocket,
@@ -324,26 +325,17 @@ class Webserver(threading.Thread):
         })
 
     def on_websocket(self, websocket):
-        listener_thread = threading.Thread(target=self.websocket_listener, args=[websocket], daemon=True)
-        listener_thread.start()
-        # Send queued messages
+        with self._ws_clients_lock:
+            self._ws_clients.add(websocket)
+        client_count = len(self._ws_clients)
+        self._logger.info(f"WebSocket client connected (total: {client_count})")
         try:
-            while True:
-                msg = self.ws_queue.get()
-                self._logger.debug(f"Sending message to client: {msg}")
-                try:
-                    websocket.send(msg)
-                except websockets.exceptions.ConnectionClosedOK:
-                    self._logger.info("WebSocket connection closed by client")
-                    break
-                except websockets.exceptions.ConnectionClosedError as e:
-                    self._logger.error(f"WebSocket connection error: {e}")
-                    break
-                except Exception as e:
-                    self._logger.error(f"WebSocket send error: {e}", exc_info=True)
-                    # Don't break here, try to continue sending other messages
-        except Exception as e:
-            self._logger.error(f"WebSocket message queue processing error: {e}", exc_info=True)
+            self.websocket_listener(websocket)
+        finally:
+            with self._ws_clients_lock:
+                self._ws_clients.discard(websocket)
+            client_count = len(self._ws_clients)
+            self._logger.info(f"WebSocket client disconnected (total: {client_count})")
 
     def websocket_listener(self, websocket):
         # Track if this WebSocket has sent its first frame to increment session_id once
@@ -689,10 +681,30 @@ class Webserver(threading.Thread):
         try:
             if not isinstance(payload, str):
                 payload = json.dumps(payload)
-            self._logger.debug(f"Queueing message for client: {payload}")
-            self.ws_queue.put(payload)
+            with self._ws_clients_lock:
+                clients = list(self._ws_clients)
+            if not clients:
+                self._logger.warning(f"No WebSocket clients connected, message dropped: {payload[:120]}...")
+                return
+            self._logger.debug(f"Broadcasting message to {len(clients)} client(s): {payload}")
+            dead = []
+            for ws in clients:
+                try:
+                    ws.send(payload)
+                except websockets.exceptions.ConnectionClosedOK:
+                    dead.append(ws)
+                except websockets.exceptions.ConnectionClosedError:
+                    dead.append(ws)
+                except Exception as e:
+                    self._logger.error(f"Error sending to WebSocket client: {e}")
+                    dead.append(ws)
+            if dead:
+                with self._ws_clients_lock:
+                    for ws in dead:
+                        self._ws_clients.discard(ws)
+                self._logger.debug(f"Removed {len(dead)} dead client(s)")
         except Exception as e:
-            self._logger.error(f"Error queueing message for client: {e}", exc_info=True)
+            self._logger.error(f"Error broadcasting message to clients: {e}", exc_info=True)
 
     def generate_post_op_note_route(self):
         """Generate a post-op note summary using annotations and notes"""

--- a/servers/web_server.py
+++ b/servers/web_server.py
@@ -429,7 +429,7 @@ class Webserver(threading.Thread):
                             self.lastProcessedFrame = frame_data
                         if 'clear_history' in data and self.msg_callback:
                             self._logger.info("Received clear_history request from client")
-                            self.msg_callback(data, 0, int(time.time() * 1000))
+                            self.msg_callback(data, 0, int(time.time() * 1000), reply_to=websocket)
                         elif 'user_input' in data and self.msg_callback:
                             try:
                                 preview = data.get('user_input')
@@ -440,7 +440,7 @@ class Webserver(threading.Thread):
                                 )
                             except Exception:
                                 self._logger.debug("Sending user_input to msg_callback (preview unavailable)")
-                            self.msg_callback(data, 0, int(time.time() * 1000))
+                            self.msg_callback(data, 0, int(time.time() * 1000), reply_to=websocket)
                     except json.JSONDecodeError:
                         self._logger.warning("Invalid JSON from client.")
                         continue
@@ -457,7 +457,6 @@ class Webserver(threading.Thread):
                     break
                 except TimeoutError as e:
                     self._logger.warning(f"WebSocket timeout error: {e}")
-                    # Attempt to gracefully close the connection
                     try:
                         websocket.close()
                     except:
@@ -705,6 +704,29 @@ class Webserver(threading.Thread):
                 self._logger.debug(f"Removed {len(dead)} dead client(s)")
         except Exception as e:
             self._logger.error(f"Error broadcasting message to clients: {e}", exc_info=True)
+
+    def send_message_to(self, payload, target_websocket):
+        """Send a message only to the given WebSocket client (e.g. reply to the client that asked)."""
+        try:
+            if not isinstance(payload, str):
+                payload = json.dumps(payload)
+            with self._ws_clients_lock:
+                if target_websocket not in self._ws_clients:
+                    self._logger.debug("Target WebSocket no longer connected, message dropped")
+                    return
+            try:
+                target_websocket.send(payload)
+                self._logger.debug(f"Sent message to single client: {payload[:80]}...")
+            except websockets.exceptions.ConnectionClosedOK:
+                with self._ws_clients_lock:
+                    self._ws_clients.discard(target_websocket)
+            except websockets.exceptions.ConnectionClosedError:
+                with self._ws_clients_lock:
+                    self._ws_clients.discard(target_websocket)
+            except Exception as e:
+                self._logger.error(f"Error sending message to client: {e}")
+        except Exception as e:
+            self._logger.error(f"Error sending message to client: {e}", exc_info=True)
 
     def generate_post_op_note_route(self):
         """Generate a post-op note summary using annotations and notes"""


### PR DESCRIPTION
The UI container was not displaying agent messages or annotations despite them being generated and sent successfully on the backend. Root cause: all WebSocket connections shared one `queue.Queue`. When a connection died, its sender loop (blocked on `queue.get()`) would eventually win the race, consume the message, fail on `websocket.send()`, and discard it — meaning no client ever received the message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI can receive targeted replies per connection, enabling messages to be directed to a specific client.

* **Improvements**
  * Broadcast delivery now reliably reaches all active clients and skips closed connections.
  * Connection counts and delivery logging improved for clearer session handling.

* **Bug Fixes**
  * Better detection and cleanup of inactive or disconnected clients to reduce dropped messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->