### PR TITLE
Allow offline UI startup

### DIFF
--- a/docker/Dockerfile.ui
+++ b/docker/Dockerfile.ui
@@ -21,6 +21,11 @@ RUN pip install --no-cache-dir tiktoken \
     openai \
     sentence-transformers
 
+# Pre-download tiktoken encoding data so it works offline
+ENV TIKTOKEN_CACHE_DIR=/opt/tiktoken_cache
+RUN mkdir -p $TIKTOKEN_CACHE_DIR && \
+    python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')"
+
 # npm deps — invalidated only when package.json / package-lock.json change
 COPY package.json package-lock.json ./
 RUN npm install


### PR DESCRIPTION
`tiktoken` downloads its tokenizer data (cl100k_base.tiktoken) from openaipublic.blob.core.windows.net at runtime, and it's not cached in the container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Enhanced offline support capabilities through build optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->